### PR TITLE
Add metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "mdserver",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mdserver",
-      "version": "0.1.0",
-      "license": "ISC",
+      "version": "0.2.0",
+      "license": "GPL-3.0",
       "dependencies": {
         "express": "^4.18.2",
         "showdown": "^2.1.0"

--- a/public/test.md
+++ b/public/test.md
@@ -1,3 +1,7 @@
+---
+title: Test File
+---
+
 # Test.md
 
 * A sample mark down file

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 A lightweight web server to serve a directory of markdown files, converting them to html on the fly. Non-markdown files are served directly.
 
-**mdserver** is a node.js application using [express](https://expressjs.com/) and [showdown](https://showdownjs.com/).
+**mdserver** is a node.js application using [Express](https://expressjs.com/) and [Showdown](https://showdownjs.com/).
 
 ## Install
 
@@ -16,15 +16,27 @@ or, with Docker
 
 ## Usage
 
-Files are only served from the `public` sub-directory, so all your HTML, CSS, and markdown (.md) files go in there. There are some (very simple) sample files provided in the repo.
+Files are only served from the `public` sub-directory, so all your HTML, CSS, and markdown (.md) files go in there. There are a couple of (very simple) sample files provided in the repo.
 
 The filename `template.html` is a magic one. This is the html that is used to wrap any converted markdown to ensure it is valid html. This file should contain placeholders for `{{title}}` and `{{content}}`. If `template.html` is not found, the converted markdown is sent as not-quite-correct HTML - which mostly works fine in current browsers.
 
-A welcome message appears at the root route, to get rid of it, ensure you have an `index.html` or `index.md` file in the public directory.
+New instalations will have a welcome message appear at the root route, to get rid of it, ensure you have an `index.html` or `index.md` file in the public directory.
+
+Since **mdserver** uses [Showdown](https://showdownjs.com/) for the markdown -> HTML conversion, all the [Showdown syntax](https://showdownjs.com/docs/markdown-syntax/) features are supported. This includes adding the title for the output HTML page using Frontmatter style. If you are using a template that includes the `{{title}}` directive, the following markdown would be output as HTML with the title 'Test File'
+```
+---
+title: Test File
+---
+
+# Test.md
+
+* A sample mark down file
+```
+The metadata included in the markdown like this is removed before the conversion to HTML.
 
 ## Contributions
 
-Are very welcome, but I'd have to learn how to deal with a pull request ☺
+Are welcome, but I'd have to learn how to deal with a pull request ☺
 
 
 ## Similar projects

--- a/server.js
+++ b/server.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const packageJson = require('./package.json');
 const showdown = require('showdown');
-const converter = new showdown.Converter();
+const converter = new showdown.Converter({metadata: true});
 
 const publicDirectory = 'public';
 const templateName = 'template.html';
@@ -54,16 +54,21 @@ function mdParser(req, res, next) {
                     res.status(500).send('Internal Server Error');
                 }
             } else {
-                const htmlContent = converter.makeHtml(data);
+                const rawHtml = converter.makeHtml(data);
 
                 if (useTemplate) {
                     // Replace placeholders with title and content using the template loaded at startup
-                    const title = path.basename(mdFilePath);
+                    let title = converter.getMetadata().title;
+                    console.log(title);
+                    if (title === undefined) {
+                        title = path.basename(mdFilePath);
+                    }
+                    
                     const templatedHtml = templateData.replace('{{title}}', title).replace('{{content}}',
-                        htmlContent);
+                        rawHtml);
                     res.send(templatedHtml);
                 } else {
-                    res.send(htmlContent);
+                    res.send(rawHtml);
                 }
             }
         })


### PR DESCRIPTION
Add Frontmatter style metadata to allow setting a page title for the HTML page output based on the YAML content at the top of the markdown file. Per [issue #1](https://github.com/IanKulin/mdserver/issues/1)